### PR TITLE
Fix getTeams() and getTeam()

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,26 @@ $ npm install @unicsmcr/hs_auth_client
 ## Provides
 ### Two Exported TypeScript Type Definitions
 
-- RequestUser
-  authId: string
-  name: string
-  email: string
-  email_verified: boolean
-  authLevel: AuthLevels
-  team?: string
+**RequestUser**
 
-- Team
-    _id: string
-    name: string
-    creator: string
-    table_no?: number
+- `authId`: string
+- `name`: string
+- `email`: string
+- `email_verified`: boolean
+- `authLevel`: AuthLevels
+- `team?`: string
+
+**Team**
+
+- `_id`: string
+- `name`: string
+- `creator`: string
+- `table_no?`: number
 
 ### Methods to query and post data
 - **getCurrentUser**: (token: string, originalUrl: string) => Promise<RequestUser>
-    originalUrl can be accessed from req object -> req.originalUrl
+
+    > originalUrl can be accessed from req object -> req.originalUrl
 - **getAllUsers**: (token: string) => Promise<RequestUser[]>
 - **putCurrentUser**: (name: string, token: string) => Promise<void>
 - **getTeams**: (token: string) => Promise<Team[]>;

--- a/index.ts
+++ b/index.ts
@@ -115,10 +115,10 @@ export async function getTeams(token: string): Promise<Team[]> {
     })
   } catch (err) { throw new Error(err); }
 
-  const teams: any = res.data;
-  if (teams.error && teams.status >= 400) { throw new Error(teams.error); }
+  const data: any = res.data;
+  if (data.error && data.status >= 400) { throw new Error(data.error); }
 
-  return teams.teams.map((team: any) => ({
+  return data.teams.map((team: any) => ({
     _id: team._id,
     name: team.name,
     creator: team.creator,

--- a/index.ts
+++ b/index.ts
@@ -118,11 +118,11 @@ export async function getTeams(token: string): Promise<Team[]> {
   const teams: any = res.data;
   if (teams.error && teams.status >= 400) { throw new Error(teams.error); }
 
-  return teams.map((team: any) => ({
-    _id: team.team._id,
-    name: team.team.name,
-    creator: team.team.creator,
-    table_no: team.team.table_no
+  return teams.teams.map((team: any) => ({
+    _id: team._id,
+    name: team.name,
+    creator: team.creator,
+    table_no: team.table_no
   }));
 }
 


### PR DESCRIPTION
This PR fixes a bug I found in the client. If you tried to execute `getTeams()` or `getTeam()`, it gave an error about `.map()`. I found that the client was trying to run map on the entire response data from the API (which is an object so has no map method).

For reference:

```js
{
   "status": 200,
   "error": "",
   "teams": [
      {
         "_id": "5e2f142e714294ee19c1ad2a",
         "name": "TestTeam",
         "creator": "5e2efe22714294ee19c1ad29"
      }
   ]
}
```

I also improved the readability of the README when it is rendered.