### PR TITLE
feat: add getTeamMembers method

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ npm install @unicsmcr/hs_auth_client
 - **putCurrentUser**: (name: string, token: string) => Promise\<void>
 - **getTeams**: (token: string) => Promise\<Team[]>;
 - **getTeam**: (token: string, teamId: string) => Promise\<Team>
+- **getTeamMembers**: (token: string, teamId: string) => Promise\<User[]>
 
 Token can be accessed from browser cookies under **Authorization**
 

--- a/src/__tests__/fixtures/teamMembers.ts
+++ b/src/__tests__/fixtures/teamMembers.ts
@@ -2,7 +2,7 @@ import { AuthUser } from '../../networking';
 
 export type TeamMembers = AuthUser[];
 
-export const teamMembers: TeamMembers[] = [
+export const teamsWithMembers: TeamMembers[] = [
 	// 2-person team
 	[
 		{

--- a/src/__tests__/fixtures/teamMembers.ts
+++ b/src/__tests__/fixtures/teamMembers.ts
@@ -1,0 +1,33 @@
+import { AuthUser } from '../../networking';
+
+export type TeamMembers = AuthUser[];
+
+export const teamMembers: TeamMembers[] = [
+	// 2-person team
+	[
+		{
+			_id: '123456',
+			name: 'John Doe',
+			email: 'johndoe@gmail.com',
+			auth_level: 'attendee',
+			team: '123'
+		},
+		{
+			_id: '1a2b3c4d5e',
+			name: 'Bob Ross',
+			email: 'bobross@outlook.com',
+			auth_level: 'attendee',
+			team: '123'
+		}
+	],
+	// 1-person team
+	[
+		{
+			_id: '34646573456',
+			name: 'Kilburn',
+			email: 'kilburn@gmail.com',
+			auth_level: 'attendee',
+			team: '456'
+		}
+	]
+];

--- a/src/__tests__/getTeamMembers.ts
+++ b/src/__tests__/getTeamMembers.ts
@@ -1,0 +1,54 @@
+process.env.AUTH_URL = '';
+
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import * as authClient from '..';
+import { teamMembers } from './fixtures/teamMembers';
+import { transformUser } from '../util/transformUser';
+
+const mock = new MockAdapter(axios);
+
+mock.onGet('/api/v1/teams/123/members').reply(200, {
+	status: 200,
+	error: '',
+	users: teamMembers[0]
+});
+
+mock.onGet('/api/v1/teams/456/members').reply(200, {
+	status: 200,
+	error: '',
+	users: teamMembers[1]
+});
+
+mock.onGet('/api/v1/teams/789/members').reply(200, {
+	status: 200,
+	error: '',
+	users: []
+});
+
+mock.onGet('/api/v1/teams/000000000000000000000000/members').reply(200, {
+	status: 200,
+	error: '',
+	users: null
+});
+
+describe('getTeamMembers(): fetches members and transforms them', () => {
+	for (const team of teamMembers) {
+		test(`${team.length} users`, async () => {
+			expect(await authClient.getTeamMembers('token', team[0].team)).toEqual(team.map(transformUser));
+		});
+	}
+});
+
+describe('getTeamMembers(): handles empty teams', () => {
+	for (const teamId of ['789', '000000000000000000000000']) {
+		test(`Team: ${teamId} (should return empty list)`, async () => {
+			expect(await authClient.getTeamMembers('token', teamId)).toEqual([]);
+		});
+	}
+});
+
+test('getTeamMembers(): throws for non-existent team', async () => {
+	await expect(authClient.getTeamMembers('token', 'MissingNo.')).rejects.toThrow();
+	await expect(authClient.getTeamMembers('token', '')).rejects.toThrow();
+});

--- a/src/__tests__/getTeamMembers.ts
+++ b/src/__tests__/getTeamMembers.ts
@@ -3,7 +3,7 @@ process.env.AUTH_URL = '';
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
 import * as authClient from '..';
-import { teamMembers } from './fixtures/teamMembers';
+import { teamsWithMembers } from './fixtures/teamMembers';
 import { transformUser } from '../util/transformUser';
 
 const mock = new MockAdapter(axios);
@@ -11,13 +11,13 @@ const mock = new MockAdapter(axios);
 mock.onGet('/api/v1/teams/123/members').reply(200, {
 	status: 200,
 	error: '',
-	users: teamMembers[0]
+	users: teamsWithMembers[0]
 });
 
 mock.onGet('/api/v1/teams/456/members').reply(200, {
 	status: 200,
 	error: '',
-	users: teamMembers[1]
+	users: teamsWithMembers[1]
 });
 
 mock.onGet('/api/v1/teams/789/members').reply(200, {
@@ -33,9 +33,9 @@ mock.onGet('/api/v1/teams/000000000000000000000000/members').reply(200, {
 });
 
 describe('getTeamMembers(): fetches members and transforms them', () => {
-	for (const team of teamMembers) {
-		test(`${team.length} users`, async () => {
-			expect(await authClient.getTeamMembers('token', team[0].team)).toEqual(team.map(transformUser));
+	for (const teamMembers of teamsWithMembers) {
+		test(`${teamMembers.length} users`, async () => {
+			expect(await authClient.getTeamMembers('token', teamMembers[0].team)).toEqual(teamMembers.map(transformUser));
 		});
 	}
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,3 +73,8 @@ export async function getTeam(token: string, teamId: string): Promise<Team> {
 
 	return team;
 }
+
+export async function getTeamMembers(token: string, teamId: string): Promise<User[]> {
+	const res = await networking.getTeamMembers(token, teamId);
+	return (res.data.users ?? []).map(transformUser);
+}

--- a/src/networking.ts
+++ b/src/networking.ts
@@ -42,6 +42,11 @@ export interface AuthAllTeamsResponse extends AuthResponse {
 	teams: AuthTeam[];
 }
 
+export interface AuthTeamMembersResponse extends AuthResponse {
+	// When fetching with id 000000000000000000000000, the request succeeds with users set as null
+	users: null|AuthUser[];
+}
+
 export async function getCurrentUser(token: string, originalUrl: string): Promise<AxiosResponse<AuthCurrentUserResponse>> {
 	return axios.get(`${AUTH_URL}/users/me`, {
 		headers: {
@@ -72,6 +77,14 @@ export async function putCurrentUser(name: string, token: string): Promise<Axios
 
 export async function getTeams(token: string): Promise<AxiosResponse<AuthAllTeamsResponse>> {
 	return axios.get(`${AUTH_URL}/teams`, {
+		headers: {
+			Authorization: token
+		}
+	});
+}
+
+export async function getTeamMembers(token: string, teamId: string): Promise<AxiosResponse<AuthTeamMembersResponse>> {
+	return axios.get(`${AUTH_URL}/teams/${teamId}/members`, {
 		headers: {
 			Authorization: token
 		}


### PR DESCRIPTION
This PR adds a `getTeamMembers(token, teamId)` method which return a list of users in the specified team.

I noticed one oddity in the Auth API itself, which is that fetching the team members for team `000000000000000000000000` actually succeeds, but has a null users property. However, fetching the members of other non-existent teams leads to a failed request. I've accounted for this in the PR, but I'm not too sure whether this is a bug in the API or if this is intended? @kzalys 