### PR TITLE
chore: exclude test files in npm package tarbell

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
 		"lint": "eslint src --ext .ts",
 		"test": "jest src --coverage"
 	},
+	"files": [
+		"dist/**/*.d.ts",
+		"dist/**/*.js"
+	],
 	"author": "unicsmcr",
 	"license": "MIT",
 	"repository": {


### PR DESCRIPTION
Only includes the relevant, built, files in the `dist` directory when creating the package.

This resulted also in the unpacked size of the package to go from 37.6 kB to 15.3kB.