### PR TITLE
fix: get authorized resources returned object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@unicsmcr/hs_auth_client",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"description": "API request paths for hs_auth platform",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/src/__tests__/getAuthorizedResources.test.ts
+++ b/src/__tests__/getAuthorizedResources.test.ts
@@ -15,7 +15,7 @@ test('getAuthorizedResources(): get authorized resources correctly', async () =>
 	mock.onGet(`/api/v2/tokens/resources/authorized?from=["hs:test"]`).reply(200, {
 		status: 200,
 		error: '',
-		authorizedURIs: ['hs:test']
+		authorizedUris: ['hs:test']
 	});
 
 	const response = await authApi.getAuthorizedResources('token', ['hs:test']);

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ export class AuthApi implements AuthApiInterface {
 
 	public async getAuthorizedResources(token: string, from: Array<string>): Promise<Array<string>> {
 		const res = await networking.getAuthorizedResources(token, from);
-		return res.data.authorizedURIs;
+		return res.data.authorizedUris;
 	}
 
 	public newUri(path: string, args?: Map<string, string>): string {

--- a/src/networking.ts
+++ b/src/networking.ts
@@ -47,7 +47,7 @@ export interface AuthTeamMembersResponse extends AuthResponse {
 }
 
 export interface AuthResourcesResponse extends AuthResponse {
-	authorizedURIs: string[];
+	authorizedUris: string[];
 }
 
 export async function getUser(token: string, userId: string): Promise<AxiosResponse<AuthUserResponse>> {


### PR DESCRIPTION
Fixes a bug with `Get authorized resources` implemented which returned the incorrect property from the object